### PR TITLE
advanced logging options and small fixes

### DIFF
--- a/thrash-protect.py
+++ b/thrash-protect.py
@@ -236,7 +236,10 @@ class OOMScoreProcessSelector(ProcessSelector):
                     max = oom_score
                     worstpid = (pid, stats.ppid)
         debug("oom scan completed - selected pid: %s" % (worstpid and worstpid[0]))
-        return self.checkParents(*worstpid)
+        if worstpid != None:
+            return self.checkParents(*worstpid)
+        else:
+            return None
 
 class LastFrozenProcessSelector(ProcessSelector):
     """Class containing one method for selecting a process to freeze,
@@ -375,7 +378,7 @@ def log_unfrozen(pid):
     else:
         try:
             unlink("/tmp/thrash-protect-frozen-pid-list")
-        except FileNotFoundError:
+        except (FileNotFoundError, OSError):
             pass
 
 def freeze_something(pids_to_freeze=None):

--- a/thrash-protect.py
+++ b/thrash-protect.py
@@ -371,7 +371,7 @@ class GlobalProcessSelector(ProcessSelector):
 
 def get_date_string():
     if config.date_human_readable:
-        return datetime.strftime(datetime.datetime.now(), "%Y-%m-%d %H:%M:%S")
+        return datetime.strftime(datetime.now(), "%Y-%m-%d %H:%M:%S")
     else:
         return str(time.time())
 
@@ -389,7 +389,7 @@ def get_process_info(pid):
 def log_frozen(pid):
     if config.log_user_data:
         with open("/var/log/thrash-protect.log", 'a') as logfile:
-            logfile.write("%s - frozen pid %5s - %s\n" % (get_date_string(), str(pid), get_process_info(pid)))
+            logfile.write("%s - frozen   pid %5s - %s\n" % (get_date_string(), str(pid), get_process_info(pid)))
     else:
         with open("/var/log/thrash-protect.log", 'a') as logfile:
             logfile.write("%s - frozen pid %s - frozen list: %s\n" % (get_date_string(), pid, frozen_pids))
@@ -398,11 +398,7 @@ def log_frozen(pid):
         logfile.write(" ".join([str(x) for x in frozen_pids]))
 
 def log_unfrozen(pid):
-    if config.log_user_data:
-        with open("/var/log/thrash-protect.log", 'a') as logfile:
-            logfile.write("%s - unfrozen pid %5s - %s\n" % (get_date_string(), str(pid), get_process_info(pid)))
-    else:
-        with open("/var/log/thrash-protect.log", 'a') as logfile:
+    with open("/var/log/thrash-protect.log", 'a') as logfile:
             logfile.write("%s - unfrozen pid %s\n" % (get_date_string(), pid))
 
     if frozen_pids:


### PR DESCRIPTION
Hello Tobixen,

In this pull request you will find two logging options:
- log_user_data : on freezing/unfreezing, logs username, CPU and memory usage, command string
- date_human_readable

These two options combined make it much easier to thump malicious/oblivious users.
I originally added these in version 0.8.something. When I updated to the latest version of thrash-protect, a couple of errors immediately showed up.
Commit 718ce81 seems to fix the problems on my system (Fedora 21).

Great little tool you've got going.

Thank you,
Xavier