### PR TITLE
Fixed where on some distribution it doesnt work

### DIFF
--- a/thrash-protect.py
+++ b/thrash-protect.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python3
 
 ### Simple-Stupid user-space program protecting a linux host from thrashing.
 ### See the README for details.


### PR DESCRIPTION
This caused by some distribution like popOS doesnt do symlink /usr/bin/python3 to /usr/bin/python caused the "thrash-protect" failed to start