### PR TITLE
README filename fixed in debian docs

### DIFF
--- a/debian/docs
+++ b/debian/docs
@@ -1,3 +1,3 @@
-README.md
+README.rst
 INSTALL.md
 AUTHORS


### PR DESCRIPTION
Just a small fix to fix the creation of the debian package working.